### PR TITLE
Allow non-"Parent Directory" link

### DIFF
--- a/apaxy/theme/footer.html
+++ b/apaxy/theme/footer.html
@@ -9,5 +9,6 @@
 </div><!--/.footer-->
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
 <script>
-$('tr:nth-child(2)').addClass('parent');
+    if ($('tr:nth-child(2) td:nth-child(2) a').text() == "Parent Directory")
+        $('tr:nth-child(2)').addClass('parent');
 </script>


### PR DESCRIPTION
Be sure this "parent" element is link for Parent Directory before add "parent" class.

![Capture](https://f.cloud.github.com/assets/846943/28984/97a8a140-4d0c-11e2-8c71-a7434394105e.PNG)
