### PR TITLE
Using a protocol-independent absolute path for google fonts

### DIFF
--- a/apaxy/theme/style.css
+++ b/apaxy/theme/style.css
@@ -5,7 +5,7 @@
     Theme name: Apaxy
     Theme author: @adamwhitcroft
 \*------------------------------------*/
-@import url('http://fonts.googleapis.com/css?family=Open+Sans');
+@import url('//fonts.googleapis.com/css?family=Open+Sans');
 /* Have to use @import for the font, as you can only specify a single stylesheet */
 * {
 	margin:0;


### PR DESCRIPTION
Using a protocol-independent url is better, especially when the website use https to transfer the webpage, just let the browser to decide which protocol it will prefer to use.
reference : http://www.paulirish.com/2010/the-protocol-relative-url/
