### PR TITLE
Changing parent specificity

### DIFF
--- a/apaxy/theme/style.css
+++ b/apaxy/theme/style.css
@@ -107,10 +107,10 @@ td {
 td a{
 	display: block;
 }
-tr.parent a[href="/"] {
+tr.parent a[href^="/"] {
 	color:#9099A3;
 }
-	.parent a[href="/"]:hover {
+	.parent a[href^="/"]:hover {
 		color:#2281d0;
 	}
 /*------------------------------------*\


### PR DESCRIPTION
Changing the .parent CSS selector to only apply to "Parent Directory"
folder.
