### PR TITLE
Fixed #122: Error pages stylesheets do not point to absolute paths.

### DIFF
--- a/apaxy/theme/400.html
+++ b/apaxy/theme/400.html
@@ -6,7 +6,7 @@
 		<title>Error 400</title>
 		<link rel="shortcut icon" href="img/icon.png">
 		<!-- Stylesheets -->
-		<link rel="stylesheet" href="theme/style.css" />
+		<link rel="stylesheet" href="/{FOLDERNAME}/theme/style.css" />
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400' rel='stylesheet' type='text/css'>
 	</head>
 	<body class="fadeDown">

--- a/apaxy/theme/403.html
+++ b/apaxy/theme/403.html
@@ -6,7 +6,7 @@
 		<title>Error 403</title>
 		<link rel="shortcut icon" href="img/icon.png">
 		<!-- Stylesheets -->
-		<link rel="stylesheet" href="theme/style.css" />
+		<link rel="stylesheet" href="/{FOLDERNAME}/theme/style.css" />
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400' rel='stylesheet' type='text/css'>
 	</head>
 	<body class="fadeDown">

--- a/apaxy/theme/404.html
+++ b/apaxy/theme/404.html
@@ -6,7 +6,7 @@
 		<title>Error 404</title>
 		<link rel="shortcut icon" href="img/icon.png">
 		<!-- Stylesheets -->
-		<link rel="stylesheet" href="theme/style.css" />
+		<link rel="stylesheet" href="/{FOLDERNAME}/theme/style.css" />
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400' rel='stylesheet' type='text/css'>
 	</head>
 	<body class="fadeDown">

--- a/apaxy/theme/408.html
+++ b/apaxy/theme/408.html
@@ -6,7 +6,7 @@
 		<title>Error 408</title>
 		<link rel="shortcut icon" href="img/icon.png">
 		<!-- Stylesheets -->
-		<link rel="stylesheet" href="theme/style.css" />
+		<link rel="stylesheet" href="/{FOLDERNAME}/theme/style.css" />
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400' rel='stylesheet' type='text/css'>
 	</head>
 	<body class="fadeDown">

--- a/apaxy/theme/500.html
+++ b/apaxy/theme/500.html
@@ -6,7 +6,7 @@
 		<title>Error 500</title>
 		<link rel="shortcut icon" href="img/icon.png">
 		<!-- Stylesheets -->
-		<link rel="stylesheet" href="theme/style.css" />
+		<link rel="stylesheet" href="/{FOLDERNAME}/theme/style.css" />
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400' rel='stylesheet' type='text/css'>
 	</head>
 	<body class="fadeDown">

--- a/apaxy/theme/502.html
+++ b/apaxy/theme/502.html
@@ -6,7 +6,7 @@
 		<title>Error 502</title>
 		<link rel="shortcut icon" href="img/icon.png">
 		<!-- Stylesheets -->
-		<link rel="stylesheet" href="theme/style.css" />
+		<link rel="stylesheet" href="/{FOLDERNAME}/theme/style.css" />
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:400' rel='stylesheet' type='text/css'>
 	</head>
 	<body class="fadeDown">


### PR DESCRIPTION
Fixes #122

## proposed changes

- Change the error page stylesheet references to use the `{FOLDERNAME}` variable, so that the user (or a script) can give the absolute path of the error page stylesheet.
- I will add an installation script to this pull request

