### PR TITLE
Improve UI & UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Apaxy may be basic, but it gives you a great deal of creative freedom when styli
 
 ## Installation
 
-apaxy requires an apache (2.2.11+) http server. The configuration of the apache http server have to set an `AllowOverride` statement for the Apaxy styled folder:
+apaxy requires an apache (2.4+) http server. The configuration of the apache http server have to set an `AllowOverride` statement for the Apaxy styled folder:
 
 ```apache
 AllowOverride Options Indexes FileInfo

--- a/apaxy/theme/apaxy-lightgallery.js
+++ b/apaxy/theme/apaxy-lightgallery.js
@@ -1,7 +1,12 @@
 var imageSelector = [
-    'tr:not(.parent) td.indexcolname a[href$=".png"]',
+    'tr:not(.parent) td.indexcolname a[href$=".gif"]'
+    'tr:not(.parent) td.indexcolname a[href$=".GIF"]'
+    'tr:not(.parent) td.indexcolname a[href$=".heic"]',
+    'tr:not(.parent) td.indexcolname a[href$=".HEIC"]',
     'tr:not(.parent) td.indexcolname a[href$=".jpg"]',
-    'tr:not(.parent) td.indexcolname a[href$=".gif"]',
+    'tr:not(.parent) td.indexcolname a[href$=".JPG"]',
+    'tr:not(.parent) td.indexcolname a[href$=".png"]',
+    'tr:not(.parent) td.indexcolname a[href$=".PNG"]',
 ].join(', ');
 
 lightGallery(document.getElementById('indexlist'), {

--- a/apaxy/theme/apaxy.js
+++ b/apaxy/theme/apaxy.js
@@ -99,11 +99,3 @@ arr.forEach(function(value){
         cont++;
 });
 document.getElementById("breadcrumb").innerHTML = bread;
-if (uri.substring(uri.length-1) != '/'){
-        var indexes = document.getElementsByClassName('indexcolname'),
-        i = indexes.length;
-        while (i--){
-            var a = indexes[i].getElementsByTagName('a')[0];
-            a.href =  uri + '/' + a.getAttribute('href',2);
-        }
-}

--- a/apaxy/theme/style.css
+++ b/apaxy/theme/style.css
@@ -164,7 +164,6 @@ th {
 }
 
 /* 2nd Column: Filename */
-
 th + th {
   width: 65%;
 }
@@ -178,11 +177,7 @@ th + th + th + th {
   width: 5%;
 }
 
-tr th:first-of-type {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
+tr th:first-of-type,
 tr td:first-of-type {
   padding-left: 10px;
   padding-right: 10px;
@@ -234,6 +229,9 @@ tr.parent a[href^="/"] {
   body {
     padding: 10px;
   }
+  /* 2nd Column: Filename */
+  .indexcolname { width: 95%; }
+  /* 3rd Column: Last Modified */
   .indexcollastmod { display: none; }
   .wrapper { max-width: 100%; }
 }
@@ -320,7 +318,6 @@ tr.parent a[href^="/"] {
 \*------------------------------------*/
 
 .breadcrumb {
-  white-space: nowrap;
   padding: 0;
   margin: 0;
 }
@@ -332,6 +329,7 @@ tr.parent a[href^="/"] {
   margin: 0 9px 20px -10px;
   padding: 0 15px;
   position: relative;
+  white-space: nowrap;
 }
 @media (prefers-color-scheme: dark) {
   .breadcrumb li {


### PR DESCRIPTION
fixes #
- Rendering of index generated by Apache-2.2. This ancient Apache version is still can be found on NASes (e.g. WD My Book Live), where it can't be updated easily.
- Rendering on small mobile screens (too wide icons column, overflow of breadcrumbs line)
- Showing of HEIC files in LightGallery.

## proposed changes
- Use CSS selectors without referencing Apache generated CSS classes, that became available in Apache-2.4.
- Allow wrapping of breadcrumbs line.
- Maximize filenames column width on small screen.
- Add HEIC to image selector for lightGallery. Also, allow for uppercase image filenames that may come from smartphones.
- Remove JS code for fixing hrefs. It seems to be needed to bypass an Apache bug and now became useless.